### PR TITLE
New magellan Spark 2.4.3+

### DIFF
--- a/custom-builds/jars/magellan/forks/README.md
+++ b/custom-builds/jars/magellan/forks/README.md
@@ -2,8 +2,8 @@
 
 The following libraries can be of use for data science with Spark.
 
-## fork-magellan-assembly-1.0.6-SNAPSHOT.jar ##
+## fork-magellan-assembly-1.0.7-SNAPSHOT.jar ##
 
 Magellan library built from the fork
-[https://github.com/mscno/magellan](https://github.com/mscno/magellan) which
+[https://github.com/rahulbsw/magellan](https://github.com/rahulbsw/magellan) which
 adds support for Spark 2.4.3 to Magellan. Built using `sbt assembly`.


### PR DESCRIPTION
Update the magellan fork to make it work with newer versions of Spark. I tested it on Databricks 6.5 (Spark 2.4.5) and it worked for me.